### PR TITLE
Fix missing supabase import

### DIFF
--- a/src/hooks/useAccountData.ts
+++ b/src/hooks/useAccountData.ts
@@ -1,6 +1,6 @@
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import type { Account } from '@/lib/types';
-import { supabase } from '@/lib/supabaseClient';
+import { supabase } from '@/lib/supabase';
 import { toast } from '@/components/ui/use-toast';
 
 export function useAccountData() {


### PR DESCRIPTION
## Summary
- fix wrong import path for the Supabase client in `useAccountData`

## Testing
- `npm run lint` *(fails: `@typescript-eslint/no-explicit-any` etc.)*

------
https://chatgpt.com/codex/tasks/task_e_684a5d4f3b9c8326acc92a931bdc5e9c